### PR TITLE
added a workaround so that agents are always rendered even when our c…

### DIFF
--- a/LICENSE.txt.meta
+++ b/LICENSE.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81a16a0fb6721084c8b4a67bf6734e10
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Characters/UMA/DynamicUMASkeleton.cs
+++ b/Scripts/Characters/UMA/DynamicUMASkeleton.cs
@@ -91,6 +91,21 @@ namespace ASAPToolkit.Unity.Characters {
             vJoints = GenerateVJoints();
             AddDefaultTargets(umaData);
             _ready = vJoints != null;
+            EnableUpdateWhenOffScreen(umaData);
+        }
+
+        /// <summary>
+        /// There is an issue with UMARenderer's SkinnedMeshRenderer Bounds location not being updated correctly when the agent is repositioned. 
+        /// This causes the problem that the agent is not rendered when the camera thinks the agent is out of view, although actually it is still in view.
+        /// As a workaround we enable the property <c>updateWhenOffScreen</c> for each of the agent's renderers to ensure it never vanishes, even when the camera thinks it's offscreen
+        /// TODO: try to figure out why the bounds are not updated after the agent is generated and moved to a different position...
+        /// </summary>
+        public void EnableUpdateWhenOffScreen(UMAData umaData)
+        {
+            foreach (SkinnedMeshRenderer smr in umaData.GetRenderers())
+            {
+                smr.updateWhenOffscreen = true;
+            }
         }
 
         public void AddDefaultTargets(UMAData umaData) {

--- a/Scripts/Middleware/UDPMultiClientMiddleware.cs
+++ b/Scripts/Middleware/UDPMultiClientMiddleware.cs
@@ -201,7 +201,7 @@ namespace ASAPToolkit.Unity.Middleware {
                         _receiveQueue.Enqueue(msg);
                     }
                 }
-                catch (Exception e)
+                catch (SocketException e)
                 {
                     //OK, since this was a bitch to figure out, here is some documentation for what is going on, and why we encounter exceptions when receiving data
 


### PR DESCRIPTION
…amera wrongfully thinks they offscreen

@Jan: this has something to do with the mesh's bounds not matching the actual location of the rendered agent. The bounds stay centred at (0,0,0) when the agent itself is rendered in a different location e.g. (0,0,2).. When the camera moves forward, e.g. to (0,0,1) it thinks the agent is offscreen and stops rendering it (i.e. it vanishes). This workaround at least ensures the agent is always rendered, but does not solve the underlying problem. 

I also tried calling smr.sharedMesh.RecalculateBounds() but this did not seem to update the location of the bounds.